### PR TITLE
Adding two user categories of skills, and adding a warning note

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ A Model Context Protocol (MCP) server and CLI that lets Claude Code call the Edg
 
 ## Skills
 
-This repository includes a `skills/` directory containing curated "skill packs" (documentation and helper scripts) for common workflows such as safe operations, issue triage, dry-run apply plans, regenerating clients, and release gating.
+If you want to use or explore the curated skill packs, see the local skills index:
 
-- Location (GitHub): https://github.com/edgeimpulse/ei-agentic-claude/tree/main/skills
+- [Skills documentation and index](./skills/README.md)
+- GitHub view: https://github.com/edgeimpulse/ei-agentic-claude/tree/main/skills
 
-Safety note: the `skills/` folder is documentation-first — it contains `SKILL.md` guides and small helper scripts (for example, `collect-logs.sh`). No credentials or secrets are stored here. The README link above will also be visible on the npm package page; it safely redirects to the GitHub `skills/` folder.
+Safety note: the `skills/` folder is documentation-first and contains `SKILL.md` guides plus small helper scripts (for example, `collect-logs.sh`). No credentials or secrets are stored here. Review helper scripts before running them locally.
 
 ## Example of usage
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ A Model Context Protocol (MCP) server and CLI that lets Claude Code call the Edg
 - Claude skill: `claude mcp add edge-impulse -- edge-impulse-mcp`
 - Status badges: CI = tests/build, Publish = npm release workflow
 
+## Skills
+
+This repository includes a `skills/` directory containing curated "skill packs" (documentation and helper scripts) for common workflows such as safe operations, issue triage, dry-run apply plans, regenerating clients, and release gating.
+
+- Location (GitHub): https://github.com/edgeimpulse/ei-agentic-claude/tree/main/skills
+
+Safety note: the `skills/` folder is documentation-first — it contains `SKILL.md` guides and small helper scripts (for example, `collect-logs.sh`). No credentials or secrets are stored here. The README link above will also be visible on the npm package page; it safely redirects to the GitHub `skills/` folder.
+
 ## Example of usage
 
 ### CLI Usage

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ A Model Context Protocol (MCP) server and CLI that lets Claude Code call the Edg
 
 ## Skills
 
+### Who this is for? Well two audiences, really:
+
+This repo serves two audiences:
+
+- **Developers / skill creators**: if you want to extend the MCP server/CLI, add new tools, regenerate the API clients, or improve tests and release workflows, use the **Development** and **Security/Integrity** sections. The `skills/` folder also includes templates and helper scripts for building safe, reproducible agent workflows.
+
+- **Project users**: if you just want to *use* Claude/OpenClaw to inspect and iterate on an Edge Impulse project, start with **Quick Start** and the **Skills** index. Use read-only flows first (list/inspect), then only enable “apply” workflows after you’ve reviewed diffs and explicitly approved any write actions.
+
+
 If you want to use or explore the curated skill packs, see the local skills index:
 
 - [Skills documentation and index](./skills/README.md)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "skills"
   ],
   "bin": {
     "edge-impulse-cli": "./dist/cli.js",

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,44 @@
+# OpenClaw Skills Pack for ei-agentic-claude
+
+This zip contains a set of local OpenClaw skills intended to be used alongside the
+`edgeimpulse/ei-agentic-claude` repository (Edge Impulse + MCP + CLI integration).
+
+## Included skills
+- `ei-safe-ops` — read-first / explicit approval for writes
+- `ei-issue-triage` — structured reproduction + safe log capture + fix plan
+- `ei-apply-flow-dryrun` — propose changes, produce diffs, never mutate
+- `ei-regenerate-clients` — regenerate generated clients + integrity gate + tests
+- `ei-release-gate` — pre-release checklist + smoke gates
+- `ei-studio-api-verify` — validate intended operations against Studio API docs
+
+## Install
+Copy the `skills/` directory into your OpenClaw skills directory, e.g.:
+
+- `~/.openclaw/skills/`  (or your configured OpenClaw workspace skills folder)
+
+Then enable skills in `openclaw.json`.
+
+## Example openclaw.json
+This is a minimal example showing skill registration. Ensure each key is unique.
+
+```json
+{
+  "skills": {
+    "install": { "nodeManager": "npm" },
+    "entries": {
+      "ei-safe-ops": { "enabled": true },
+      "ei-issue-triage": { "enabled": true },
+      "ei-apply-flow-dryrun": { "enabled": true },
+      "ei-regenerate-clients": { "enabled": true },
+      "ei-release-gate": { "enabled": true },
+      "ei-studio-api-verify": { "enabled": true }
+    }
+  }
+}
+```
+
+Verify registration:
+
+```bash
+openclaw skills list
+```

--- a/skills/REVIEW.md
+++ b/skills/REVIEW.md
@@ -1,0 +1,32 @@
+# Validation notes against Edge Impulse Studio API docs
+
+This pack is designed to be compatible with the Studio API surface and interaction patterns
+documented at: https://docs.edgeimpulse.com/apis/studio#studio-api
+
+## Key constraints reflected in skills
+
+1. Base URL
+- Studio API base URL is `https://studio.edgeimpulse.com/v1`.
+
+2. Auth types
+- Supports API key auth via `x-api-key` header.
+- JWT auth exists but API-key is the simplest for project-scoped automation.
+
+3. Project-scoped routing
+- Most endpoints are under `/v1/api/{projectId}/...`.
+
+4. Jobs model
+- Long-running tasks return a job identifier and should be polled/monitored.
+- Skills emphasize planning + verification around job-based workflows.
+
+5. Deprecated endpoints awareness
+- Some endpoints (e.g. legacy deployment download) are marked deprecated; skills recommend
+  confirming and using replacements.
+
+## Where to extend
+If you add new skills that execute writes, ensure:
+- explicit confirmation gate (ei-safe-ops)
+- a before/after snapshot and diff
+- a rollback plan
+- avoid deprecated endpoints and prefer documented replacements
+

--- a/skills/ei-apply-flow-dryrun/SKILL.md
+++ b/skills/ei-apply-flow-dryrun/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: ei-apply-flow-dryrun
+description: "Generate optimization/configuration proposals for an Edge Impulse project and produce a dry-run apply pack (no server mutations)."
+user-invocable: true
+---
+
+# Apply Flow (Dry-Run Only)
+
+## Hard rule
+Do **NOT** run any command that changes server state (no create/update/delete/train/apply).
+If the user requests a write action, stop and provide:
+- a plan,
+- the exact commands that would be executed,
+- what the user should verify before running them.
+
+## Workflow
+1. Identify the target project (read-only)
+   - list projects
+   - match by name/id
+
+2. Snapshot current configuration (read-only where possible)
+   - export relevant JSON/config/state
+   - record timestamps and IDs
+
+3. Propose changes
+   - rationale
+   - expected impact (accuracy vs latency vs memory)
+   - risks and rollback
+
+4. Output a “Dry-Run Apply Pack”
+   - `outputs/apply-dryrun/<project-id>/before.json`
+   - `outputs/apply-dryrun/<project-id>/proposed.json`
+   - `outputs/apply-dryrun/<project-id>/diff.md`
+   - `outputs/apply-dryrun/<project-id>/commands.sh` (not executed)
+
+## Notes
+This skill is intended to pair with tools that can read project configuration via the Studio API
+and the `ei-agentic-claude` CLI/MCP integration.

--- a/skills/ei-issue-triage/SKILL.md
+++ b/skills/ei-issue-triage/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: ei-issue-triage
+description: "Triage workflow for ei-agentic-claude issues: reproduce, collect logs safely, isolate root cause, propose patch and regression tests."
+user-invocable: true
+---
+
+# EI Issue Triage
+
+## Purpose
+Standardize how issues in `ei-agentic-claude` are debugged, reproduced, and fixed without leaking secrets.
+
+## Inputs (do not request secrets)
+- Exact command(s) run
+- Full error output + stack trace
+- OS + Node version (`node -v`, `npm -v`)
+- Whether running from TypeScript sources (ts-node) or `dist`
+- Whether using CLI, MCP, or Docker
+
+## Workflow
+1. **Baseline**
+   - `npm ci`
+   - `npm run build`
+   - `npm test`
+   - Optional container smoke: `npm run docker:test`
+
+2. **Reproduce**
+   - Reduce to the smallest command/tool-call that triggers the issue.
+   - Capture output to a local log file.
+
+3. **Collect diagnostics safely**
+   - Node/npm versions, git hash, and env var *presence only* (present/missing).
+   - Do not dump `.env` or token values.
+
+4. **Isolate category**
+   - Parsing / command routing
+   - Auth & headers
+   - Generated client integrity
+   - Sandbox/runtime
+   - Rate limits / API contract drift
+   - Docker packaging
+
+5. **Fix plan**
+   - File(s) to change and why
+   - Minimal patch steps
+   - Regression tests to add
+   - Docs updates if necessary
+
+6. **Artifacts**
+   - `outputs/triage/<issue-id>/repro.md`
+   - `outputs/triage/<issue-id>/logs.txt`
+   - `outputs/triage/<issue-id>/fix-plan.md`
+
+## Helper script
+Use `scripts/collect-logs.sh <issue-id>` to create an initial log bundle.

--- a/skills/ei-issue-triage/scripts/collect-logs.sh
+++ b/skills/ei-issue-triage/scripts/collect-logs.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ISSUE_ID="${1:-unknown}"
+OUT_DIR="outputs/triage/${ISSUE_ID}"
+mkdir -p "${OUT_DIR}"
+
+{
+  echo "== System =="
+  uname -a || true
+  echo
+  echo "== Node/NPM =="
+  node -v || true
+  npm -v || true
+  echo
+  echo "== Git =="
+  git rev-parse HEAD || true
+  git status --porcelain || true
+  echo
+  echo "== Env presence (no values) =="
+  for k in EI_API_KEY ANTHROPIC_API_KEY; do
+    if [ -n "${!k-}" ]; then echo "${k}=present"; else echo "${k}=missing"; fi
+  done
+} > "${OUT_DIR}/env.txt"
+
+echo "Wrote: ${OUT_DIR}/env.txt"
+echo "Next: append failing command output to ${OUT_DIR}/logs.txt (do not include secrets)."

--- a/skills/ei-regenerate-clients/SKILL.md
+++ b/skills/ei-regenerate-clients/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: ei-regenerate-clients
+description: "Regenerate generated API clients/CLI commands, refresh integrity hashes, and run verification tests for ei-agentic-claude."
+user-invocable: true
+---
+
+# Regenerate Clients + Integrity Gate
+
+## Purpose
+When the Studio API evolves, the generated clients and CLI commands need to be regenerated and verified.
+
+## Workflow
+1. Clean install + build
+   - `npm ci`
+   - `npm run build`
+
+2. Regenerate generated sources
+   - Run the repo’s Postman/OpenAPI generation workflow used to produce:
+     - generated API clients
+     - generated CLI command wrappers
+
+3. Refresh integrity hashes
+   - `npm run generate-integrity`
+
+4. Verify
+   - `npm test`
+   - `npm run docker:test`
+
+## Acceptance criteria
+- Generated outputs land only in expected generated directories.
+- `integrity.json` updates to match regenerated outputs.
+- Tests pass before opening a PR.
+
+## Output (recommended)
+Create a PR description that includes:
+- what changed in the upstream definition
+- regeneration commands executed
+- test commands executed

--- a/skills/ei-release-gate/SKILL.md
+++ b/skills/ei-release-gate/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: ei-release-gate
+description: "Release candidate checklist: build, test, docker smoke, and release notes draft for ei-agentic-claude."
+user-invocable: true
+---
+
+# Release Gate (RC)
+
+## Preconditions
+- Working tree clean (`git status --porcelain` empty)
+- On the correct release branch/tag
+- Secrets remain local (`.env` files git-ignored)
+
+## Gate steps
+1. Install/build
+   - `npm ci`
+   - `npm run build`
+
+2. Unit tests
+   - `npm test`
+
+3. Docker smoke
+   - `npm run docker:test`
+
+4. Manual smoke (read-only)
+   - `node launch-cli.mjs --help`
+   - Optional (if API key available): `node launch-cli.mjs get-all-projects --api-key $EI_API_KEY`
+
+5. Draft release notes (output only)
+Create `outputs/release/notes.md` containing:
+- Summary of changes
+- Breaking changes
+- Upgrade notes
+- Security notes
+
+## Stop conditions
+Stop if any gate fails or if secrets appear in outputs.

--- a/skills/ei-safe-ops/SKILL.md
+++ b/skills/ei-safe-ops/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: ei-safe-ops
+description: "Guard-railed operating procedure for using the Edge Impulse MCP server and CLI safely (read-only first, explicit approval before writes)."
+user-invocable: true
+---
+
+# EI Safe Ops
+
+## Purpose
+This skill provides guardrails for operating `ei-agentic-claude` (CLI and MCP server) in a safe, repeatable way.
+
+## Operating rules
+1. **Default to READ operations**:
+   - List, get, describe, inspect, export, status.
+   - Do not change server state unless the user explicitly approves.
+
+2. **No secret exposure**:
+   - Never print API keys, tokens, `.env` contents, or full environment dumps.
+   - If checking keys exist, state only **present/missing**.
+
+3. **Before ANY write operation** (create/update/delete/train/apply):
+   - Produce a **Change Plan** containing:
+     - Objective
+     - Exact endpoint(s) or CLI command(s) to be invoked
+     - Risks
+     - Rollback steps
+     - Artifacts/logs to be saved
+   - Ask: **"Proceed with write operations? (yes/no)"**
+   - If no, stop and provide only the plan.
+
+4. **For project configuration changes**:
+   - Capture a **before snapshot** (JSON export/config text).
+   - Propose edits and show a diff.
+   - Prefer dry-run mode when possible.
+
+5. **After execution (when approved)**:
+   - Re-query state to confirm changes took effect.
+   - Save outputs to `outputs/` and summarize results.
+
+## Example interactions
+- "List my Edge Impulse projects" → read-only actions, no approval required.
+- "Change my impulse config" → Change Plan + explicit approval required.


### PR DESCRIPTION
This pull request introduces a new `skills/` directory to the repository, which provides curated skill packs for common workflows. The changes also ensure that this directory is included in the published npm package. Here are the most important changes:

Skills directory introduction:

* Added a `skills/` directory containing documentation (`SKILL.md` guides) and helper scripts for workflows like safe operations, issue triage, dry-run apply plans, and release gating. No credentials or secrets are stored here, and the directory is documentation-first. (`README.md`)
* Provided a link to the `skills/` directory in the README, which is also visible on the npm package page and safely redirects to GitHub. (`README.md`)

Package publishing updates:

* Updated `package.json` to include the `skills` directory in the npm package files, ensuring skill packs are distributed with the package. (`package.json`)